### PR TITLE
Frame fix

### DIFF
--- a/iblvideo/__init__.py
+++ b/iblvideo/__init__.py
@@ -1,5 +1,5 @@
 
-__version__ = 'iblvideo_2.2.0'  # This is the only place where the version is hard coded, only adapt here
+__version__ = 'iblvideo_2.2.1'  # This is the only place where the version is hard coded, only adapt here
 
 import deeplabcut
 

--- a/iblvideo/choiceworld.py
+++ b/iblvideo/choiceworld.py
@@ -117,7 +117,7 @@ def _s00_transform_rightCam(file_mp4, tdir, nframes, force=False):
         _logger.info('STEP 00b Oversampled rightCamera video exists, not computing.')
     else:
         _logger.info('STEP 00b START Oversampling rightCamera video')
-        command_upsample = (f'ffmpeg -nostats -y -loglevel 0 -i {file_out1} -frames:v {nframes}'
+        command_upsample = (f'ffmpeg -nostats -y -loglevel 0 -i {file_out1} -frames:v {nframes} '
                             f'-vf scale=1280:1024 {file_out2}')
         pop = _run_command(command_upsample)
         if pop['process'].returncode != 0:

--- a/iblvideo/tests/download_test_data.py
+++ b/iblvideo/tests/download_test_data.py
@@ -28,7 +28,7 @@ def _download_dlc_test_data(version=__version__, one=None):
 
     # Construct URL and call download
     url = '{}/dlc_test_data_v{}.zip'.format(str(data_dir), '.'.join(version.split('_')[-1].split('.')[:-1]))
-    file_name, hash = one.alyx.download_file(url, cache_dir=local_path, return_md5=True, silent=True)
+    file_name, hash = one.alyx.download_file(url, target_dir=local_path, return_md5=True, silent=True)
     file_name = Path(file_name)
     _logger.info(f"Downloaded test data hash: {hash}, {file_name}")
     # unzip file
@@ -58,7 +58,7 @@ def _download_me_test_data(one=None):
 
     # Construct URL and call download
     url = '{}/me_test_data.zip'.format(str(data_dir))
-    file_name, hash = one.alyx.download_file(url, cache_dir=local_path, return_md5=True, silent=True)
+    file_name, hash = one.alyx.download_file(url, target_dir=local_path, return_md5=True, silent=True)
     file_name = Path(file_name)
     # unzip file
     test_dir = file_name.parent.joinpath(file_name.stem)


### PR DESCRIPTION
Add in condition that the number of dlc points must match the number of video frames. There were some problems for the codec of the video collected in the widefield task. These changes fix the problem and dlc has been running without problems on their sessions