### PR TITLE
fix ROI on frame boundary bug

### DIFF
--- a/iblvideo/__init__.py
+++ b/iblvideo/__init__.py
@@ -1,5 +1,5 @@
 
-__version__ = '3.0.1'  # This is the only place where the version is hard coded, only adapt here
+__version__ = '3.0.2'  # This is the only place where the version is hard coded, only adapt here
 
 __dlc_version__ = 'v2.2'  # versioning for DLC weights/test data
 __lp_version__ = 'v2.1'  # versioning for LP weights/test data

--- a/iblvideo/pose_lp_utils.py
+++ b/iblvideo/pose_lp_utils.py
@@ -260,7 +260,7 @@ def build_dataloader(
         crop_w, crop_h, crop_x, crop_y = crop_window
         frame_height, frame_width = original_dims
 
-        # first, adjust crop_x and crop_y to ensure they stay within frame boundaries
+        # check if crop extends beyond left/top edge
         if crop_x < 0:
             crop_x = 0
         if crop_y < 0:

--- a/iblvideo/pose_lp_utils.py
+++ b/iblvideo/pose_lp_utils.py
@@ -260,6 +260,18 @@ def build_dataloader(
         crop_w, crop_h, crop_x, crop_y = crop_window
         frame_height, frame_width = original_dims
 
+        # first, adjust crop_x and crop_y to ensure they stay within frame boundaries
+        if crop_x < 0:
+            crop_x = 0
+        if crop_y < 0:
+            crop_y = 0
+
+        # check if crop extends beyond right/bottom edge
+        if crop_x + crop_w > frame_width:
+            crop_x = frame_width - crop_w
+        if crop_y + crop_h > frame_height:
+            crop_y = frame_height - crop_h
+
         # dali normalizes crop params in a funny way
         crop_x_norm = crop_x / (frame_width - crop_w)
         crop_y_norm = crop_y / (frame_height - crop_h)


### PR DESCRIPTION
If the eye, nose, or tongue is too close to the boundary of the frame, the crop parameters can extend beyond the frame, raising an error in the DALI dataloader. This PR forces the ROI to lie fully within the frame, even if the eye/nose/tongue is no longer centered in the ROI.