### PR TITLE
continuous integration for cpu-based tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,10 +25,16 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install torch --index-url https://download.pytorch.org/whl/cpu
           pip install -e ".[dev,action]"
 
       - name: Set up ONE
-        run: python -c "from one.api import ONE; ONE.setup(base_url='https://openalyx.internationalbrainlab.org', silent=True); one = ONE(password='international', silent=True)"
+        run: |
+          python - <<'EOF'
+          from one.api import ONE
+          ONE.setup(base_url='https://openalyx.internationalbrainlab.org', silent=True)
+          one = ONE(password='international', silent=True)
+          EOF
 
       - name: Run tests
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,35 @@
+name: Run Tests
+
+on:
+  # Allow manually running from Github UI or API.
+  workflow_dispatch:
+  push:
+    branches: [master]
+  # to re-run status checks, mark as draft then ready_for_review
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev,action]"
+
+      - name: Set up ONE
+        run: python -c "from one.api import ONE; ONE.setup(base_url='https://openalyx.internationalbrainlab.org', silent=True); one = ONE(password='international', silent=True)"
+
+      - name: Run tests
+        run: |
+          pytest tests/test_motion_energy.py tests/test_segmentation_la.py


### PR DESCRIPTION
* add github workflow for continuous integration
* run motion energy and lightning action tests, which only require cpu