### PR TITLE
update LP version

### DIFF
--- a/iblvideo/pose_lp.py
+++ b/iblvideo/pose_lp.py
@@ -9,8 +9,8 @@ import cv2
 import numpy as np
 import pandas as pd
 import torch
-from lightning_pose.utils.predictions import create_labeled_video
-from moviepy.editor import VideoFileClip
+from lightning_pose.utils.predictions import _create_labeled_video as create_labeled_video
+from moviepy import VideoFileClip
 
 from iblvideo.params_lp import BODY_VIDEO, LEFT_VIDEO, RIGHT_VIDEO
 from iblvideo.pose_lp_utils import analyze_video, get_crop_window, run_eks

--- a/iblvideo/pose_lp_utils.py
+++ b/iblvideo/pose_lp_utils.py
@@ -14,11 +14,12 @@ import yaml
 from eks.ibl_pupil_smoother import ensemble_kalman_smoother_ibl_pupil
 from eks.singlecam_smoother import ensemble_kalman_smoother_singlecam
 from eks.utils import convert_lp_dlc
+from lightning_pose.api.model import load_model_from_checkpoint
 from lightning_pose.data import _IMAGENET_MEAN, _IMAGENET_STD
 from lightning_pose.data.dali import LitDaliWrapper
 from lightning_pose.data.utils import count_frames
-from lightning_pose.utils.predictions import PredictionHandler, load_model_from_checkpoint
-from moviepy.editor import VideoFileClip
+from lightning_pose.utils.predictions import PredictionHandler
+from moviepy import VideoFileClip
 from nvidia.dali import pipeline_def
 from nvidia.dali.plugin.pytorch import LastBatchPolicy
 from omegaconf import DictConfig

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ action = [
     "lightning-action==0.2.4",
 ]
 pose = [
-    "lightning-pose==1.6.1",
+    "lightning-pose==2.2.0",
     "ensemble-kalman-smoother==3.0.0",
 ]
 all = [


### PR DESCRIPTION
The current code pins `lightning-pose==1.6.1`, which is quite an old LP version. This PR updates to `lightning-pose==2.2.0`, which was released at the end of May 2026. Importantly, v1.6.1 pinned `numpy<2.0.0` because of another dependency (`imgaug`), while the currently pinned version of `lightning-action` (0.2.4)  pins `numpy>=2.0.0` (due to a migration from `imgaug` to `imaug`). This meant that LP and LA could not be installed together in a single environment, complicating testing and deployment. With the update to 2.2.0 `lightning-pose` now pins `numpy>=2.0.0`, and both LP and LA can be installed in the same environment if desired.

There is a newer LP version, `2.2.1`, but this version introduces config validation through pydantic. The models that we have saved on AWS have config files that will fail this validation, because they have (irrelevant) fields that are no longer present, and will fail the strict checking. In the future we can either modify the config files of the models on AWS, or train new models from scratch with the updated codebase.