### PR TITLE
main->master branch in test workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,7 @@ name: Run tests
 on:
   push:
     branches:
-      - main
+      - master
   pull_request_target:
     types: [opened, synchronize, reopened]
 


### PR DESCRIPTION
bugfix, we still use `master` in this repo instead of `main`